### PR TITLE
Remove a line that was causing edoc problems.

### DIFF
--- a/src/p1_options.erl
+++ b/src/p1_options.erl
@@ -1,6 +1,5 @@
 %%%-------------------------------------------------------------------
 %%% @author Evgeny Khramtsov <ekhramtsov@process-one.net>
-%%% Created : 24 Apr 2017 by Evgeny Khramtsov <ekhramtsov@process-one.net>
 %%%
 %%%
 %%% Copyright (C) 2002-2017 ProcessOne, SARL. All Rights Reserved.


### PR DESCRIPTION
This commit drops a comment that was causing edoc to fail to
build the documentation, with the following error:

./src/p1_options.erl, in module header: at line 3:
multiple '<...>' sections.

The line had duplicate information since the creation date is in
git history and the author is already noted in the line above.
Thus, it was simplest to remove the line.

Without this patch, I was receiving this error on Fedora Rawhide with erlang-edoc-19.3.6-2.fc27.x86_64 and erlang-rebar-2.6.4-3.fc26.x86_64:

```
$ /usr/bin/rebar doc -vv                                                                                               
DEBUG: Evaluating config script "/home/rbarlow/rpmbuild/BUILD/p1_utils-1.0.9/rebar.config.script"
DEBUG: Consult config file "/home/rbarlow/rpmbuild/BUILD/p1_utils-1.0.9/rebar.config"                                  
DEBUG: Rebar location: "/usr/bin/rebar"                    
DEBUG: Consult config file "/home/rbarlow/rpmbuild/BUILD/p1_utils-1.0.9/src/p1_utils.app.src"
DEBUG: Available deps: []                                                                                              
DEBUG: Missing deps  : []                                                                                              
DEBUG: Plugins requested while processing /home/rbarlow/rpmbuild/BUILD/p1_utils-1.0.9: []
DEBUG: Predirs: []                                         
==> p1_utils-1.0.9 (doc)                                   
DEBUG: "doc/overview.edoc" is more recent than "doc/edoc-info": {{2017,6,7},{4,29,42}} > 0
INFO:  Regenerating edocs for p1_utils                     
./src/p1_options.erl, in module header: at line 3: multiple '<...>' sections.
edoc: skipping source file './src/p1_options.erl': {'EXIT',error}.
edoc: error in doclet 'edoc_doclet': {'EXIT',error}.       
ERROR: doc failed while processing /home/rbarlow/rpmbuild/BUILD/p1_utils-1.0.9: {'EXIT',error}
```

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>