### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.1.0
+
+* Add module for decoding HAproxy protocol (v1 and v2) headers
+
 # Version 1.0.23
 
 * Switch from using Travis to Github Actions as CI


### PR DESCRIPTION
It would be nice if you could publish a new release with the `p1_proxy_protocol` module ([maybe bump the version][1] to 1.1.0?).

[1]: https://semver.org/#spec-item-7