### PR TITLE
Fix to pass Eunit tests with Erlang/OTP 26

### DIFF
--- a/src/p1_file_queue.erl
+++ b/src/p1_file_queue.erl
@@ -200,7 +200,9 @@ format_error({not_owner, Path}) ->
     "not a file queue owner (" ++ binary_to_list(Path) ++ ")";
 format_error({Posix, Path}) ->
     case file:format_error(Posix) of
-	"unknown POSIX error" ->
+	"unknown POSIX error" ->  % Erlang/OTP 25 and older
+	    atom_to_list(Posix) ++ " (" ++ binary_to_list(Path) ++ ")";
+	[$u, $n, $k, $n, $o, $w, $n | _] -> % Erlang/OTP 26 and newer
 	    atom_to_list(Posix) ++ " (" ++ binary_to_list(Path) ++ ")";
 	Reason ->
 	    Reason ++ " (" ++ binary_to_list(Path) ++ ")"


### PR DESCRIPTION
In Erlang 25 and older an unknown error message is formatted like this:

  1> file:format_error(unexpected).
  "unknown POSIX error"

However since Erlang 26 the resulst is different:

  1> file:format_error(unexpected).
  "unknown POSIX error: unexpected"

Let's add another case to handle both variants.

(Based on processone/pkix@fea53406624283fd124db288f7d20724e62477a5)